### PR TITLE
[fix] add check_shm_size 20m to nginx.conf

### DIFF
--- a/resource/nginx/nginx.template
+++ b/resource/nginx/nginx.template
@@ -23,7 +23,7 @@ http {
     ##
     # Basic Settings
     ##
-
+    check_shm_size 20m;
 	charset utf-8;
     sendfile on;
     tcp_nopush on;


### PR DESCRIPTION
Type: Fix
Effect: Fix master-slave synchronization failure when there are many rules.